### PR TITLE
Move artifact updates to main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,3 @@ jobs:
       - run: yarn
       - run: yarn build
       - run: yarn test
-      - name: Update artifacts
-        run: |
-          git config --global user.email "github-actions@users.noreply.github.com"
-          git config --global user.name "github-actions"
-          git commit -am "[automated] Update artifacts" || echo "No changes to commit"
-          git push

--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -17,5 +17,5 @@ jobs:
         run: |
           git config --global user.email "github-actions@users.noreply.github.com"
           git config --global user.name "github-actions"
-          git commit -am "[automated] Update artifacts" || echo "No changes to commit"
+          git commit -am "[automated] Update artifacts [skip ci]" || echo "No changes to commit"
           git push

--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -6,8 +6,8 @@ on:
       - v*
 
 jobs:
-  test:
-    name: "Run Tests"
+  update-artifacts:
+    name: "Update artifacts"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/update-artifacts.yml
+++ b/.github/workflows/update-artifacts.yml
@@ -1,0 +1,21 @@
+name: "Update artifacts"
+
+on:
+  push:
+    branches:
+      - v*
+
+jobs:
+  test:
+    name: "Run Tests"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: yarn
+      - run: yarn build
+      - name: Update artifacts
+        run: |
+          git config --global user.email "github-actions@users.noreply.github.com"
+          git config --global user.name "github-actions"
+          git commit -am "[automated] Update artifacts" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
The previous PR (#11) introduced a mechanism to automatically update the build artifacts in this repository. The way it worked was that after running the tests, the build artifacts would be commited. This, however, is not possible with dependabot, since it creates a fork in another repository. Thus, you cannot commit within the github action.

This PR will move the artifact update logic to the main version branches (v*), to allow the artifacts to updated after a merge. This should be fine, since the merge does not introduce new changes to the build process (the build is ran on the branch before the tests anyway).